### PR TITLE
fix/foreman sig kill bug

### DIFF
--- a/checkmate/bin/dev
+++ b/checkmate/bin/dev
@@ -13,4 +13,4 @@ export PORT="${PORT:-3000}"
 export RUBY_DEBUG_OPEN="true"
 export RUBY_DEBUG_LAZY="true"
 
-exec foreman start -f Procfile.dev "$@"
+foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Currently when doing control c with bin/dev, the child process seems to be lingering and results in the cmd not showing what I type, this should fix it

Please test